### PR TITLE
Incorrect Package Manager Installation (npm instead of Yarn) #23

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Make sure you have [Node.js](http://nodejs.org/) installed.
 
 ```sh
 git clone https://github.com/yashchaudhari008/tic-tac-toe.git
-npm install
-npm start
+yarn install
+yarn start
 ```
 
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.


### PR DESCRIPTION
I have changed the instructions of how to use the clone and install the project from 
"npm install and npm run" to"yarn install and yarn run".